### PR TITLE
Add NixOS rebuild tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -43,6 +43,20 @@
         "isDefault": true
       },
       "problemMatcher": []
-    }
+    },
+    {
+      "label": "deploy: boot",
+      "type": "shell",
+      "command": "sudo nixos-rebuild boot --flake .",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "deploy: switch",
+      "type": "shell",
+      "command": "sudo nixos-rebuild switch --flake .",
+      "group": "build",
+      "problemMatcher": []
+    },
   ]
 }


### PR DESCRIPTION
Add 'deploy: boot' and 'deploy: switch' tasks to simplify deploying the NixOS configuration directly from the editor.