### PR TITLE
feat(pluto): patch plasma-workspace systemtray icons

### DIFF
--- a/hosts/pluto.nix
+++ b/hosts/pluto.nix
@@ -435,6 +435,27 @@
     user = "maik";
   };
 
+  ###########
+  # Patches #
+  ###########
+
+  # Customize kde plasma
+  nixpkgs.overlays = [
+    (final: prev: {
+      kdePackages = prev.kdePackages.overrideScope (sfinal: sprev: {
+        # smaller systemtray icons with more spacing
+        # FIXME: this compiles plasma-workspace just to patch qml script
+        plasma-workspace = sprev.plasma-workspace.overrideAttrs (oldAttrs: {
+          patches =
+            oldAttrs.patches
+            ++ [
+              ../patches/0001-plasma-workspaces-systemtray-icon-sizes.patch
+            ];
+        });
+      });
+    })
+  ];
+
   # NixOS state version
   capabilities.llama-cpp = {
     enable = true;


### PR DESCRIPTION
Apply a custom patch via a nixpkgs overlay to reduce the size of KDE Plasma system tray icons and increase their spacing.