### PR TITLE
Enable lanzaboote for secure boot

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
         modules = [
           ./hosts/pluto.nix
           agenix.nixosModules.default
+          lanzaboote.nixosModules.lanzaboote
         ];
         specialArgs = {
         };
@@ -120,7 +121,7 @@
           };
         };
       in {
-        pluto = pkgs.testers.nixosTest (import ./tests/pluto.nix {inherit agenix;});
+        pluto = pkgs.testers.nixosTest (import ./tests/pluto.nix {inherit agenix lanzaboote;});
         styx = pkgs.testers.nixosTest (import ./tests/styx.nix {inherit agenix intel-lpmd-flake lanzaboote;});
         juno = pkgs.testers.nixosTest (import ./tests/juno.nix {inherit agenix;});
         flore = pkgs.testers.nixosTest (import ./tests/flore.nix {inherit agenix;});

--- a/hosts/pluto.nix
+++ b/hosts/pluto.nix
@@ -39,6 +39,28 @@
   # Emulate aarch64
   boot.binfmt.emulatedSystems = ["aarch64-linux"];
 
+  # Lanzaboote replaces the systemd-boot module.
+  boot.loader.systemd-boot.enable = lib.mkForce false;
+
+  # Use lanzaboote for secure and measured boot
+  boot.lanzaboote = {
+    enable = true;
+    pkiBundle = "/var/lib/sbctl";
+    autoEnrollKeys = {
+      enable = true;
+      autoReboot = true;
+    };
+    autoGenerateKeys.enable = true;
+    measuredBoot = {
+      enable = true;
+      pcrs = [
+        0
+        4
+        7
+      ];
+    };
+  };
+
   # Use zram as swap
   zramSwap = {
     enable = true;

--- a/tests/pluto.nix
+++ b/tests/pluto.nix
@@ -1,10 +1,14 @@
-{agenix}: {
+{
+  agenix,
+  lanzaboote,
+}: {
   name = "pluto";
 
   nodes.machine = {lib, ...}: {
     imports = [
       ../hosts/pluto.nix
       agenix.nixosModules.default
+      lanzaboote.nixosModules.lanzaboote
     ];
 
     # Increase memory and cores for the VM


### PR DESCRIPTION
Add the lanzaboote module to the pluto host and update its NixOS test accordingly. This replaces systemd-boot to configure secure and measured boot, alongside automatic key generation and enrollment.