### PR TITLE
Replace greetd with SDDM for display management

### DIFF
--- a/hosts/pluto.nix
+++ b/hosts/pluto.nix
@@ -45,15 +45,18 @@
     algorithm = "zstd";
   };
 
-  # Autologin with greetd
-  services.greetd = {
-    enable = true;
-    settings = rec {
-      initial_session = {
-        command = "${pkgs.kdePackages.plasma-workspace}/bin/startplasma-wayland";
-        user = "maik";
+  # Manage displays with SDDM
+  services.displayManager = {
+    autoLogin = {
+      enable = true;
+      user = "maik";
+    };
+    sddm = {
+      enable = true;
+      wayland = {
+        enable = true;
+        compositor = "kwin";
       };
-      default_session = initial_session;
     };
   };
 


### PR DESCRIPTION
- Replace `services.greetd` with `services.displayManager.sddm` in `hosts/pluto.nix`.
- Enable SDDM with Wayland support using the kwin compositor.
- Update the autologin configuration to use the `services.displayManager.autoLogin` options while keeping the user set to "maik".