### PR TITLE
Enable kernel energy efficiency options

### DIFF
--- a/hardware/styx.nix
+++ b/hardware/styx.nix
@@ -24,6 +24,24 @@
     options iwlwifi power_save=1
   '';
 
+  # Optimize kernel config for this platform
+  boot.kernelPatches = [
+    {
+      name = "energy-efficiency";
+      patch = null;
+      structuredExtraConfig = with lib.kernel; {
+        # Read thermal feedback information
+        INTEL_HFI_THERMAL = yes;
+        # Support for reading thermal information
+        INT340X_THERMAL = yes;
+        # Model energy consumption, see https://docs.kernel.org/power/energy-model.html
+        ENERGY_MODEL = yes;
+        # Prefer energy efficiency by default
+        WQ_POWER_EFFICIENT_DEFAULT = yes;
+      };
+    }
+  ];
+
   # Luks encrypted root partition
   boot.initrd.luks.devices.NIXOS = {
     device = "/dev/disk/by-partlabel/NIXOS";


### PR DESCRIPTION
Configure kernel parameters to improve power management and thermal feedback. Enable INTEL_HFI_THERMAL, INT340X_THERMAL, ENERGY_MODEL, and WQ_POWER_EFFICIENT_DEFAULT to optimize overall energy efficiency on this specific hardware.