### PR TITLE
Enable thermald for thermal management

### DIFF
--- a/hosts/styx.nix
+++ b/hosts/styx.nix
@@ -328,6 +328,8 @@
     debug = true;
   };
 
+  services.thermald.enable = true;
+
   ############
   # Programs #
   ############


### PR DESCRIPTION
Enable thermald on the styx host to help regulate system temperature and prevent overheating under heavy load.